### PR TITLE
[semver:patch] Fix modules file processing

### DIFF
--- a/src/common/description/default-modules.txt
+++ b/src/common/description/default-modules.txt
@@ -1,4 +1,5 @@
 A comma-separated list of default modules that will always be added to the << modules-path >>.
 Each module must have `.circleci/config.yml` in it.
 Specifying the full paths from repository root to config files is also allowed.
-Example: `module1,.circleci/custom-config.yml`
+If a path to a custom config yaml file is specified - it must end in `config.yml`
+Example: `module1,.circleci/custom-config.yml,/path/to/custom-config.yml`

--- a/src/scripts/prepare_modules.py
+++ b/src/scripts/prepare_modules.py
@@ -11,12 +11,20 @@ DEFAULT_MODULES_PATH = "/tmp/modules.txt"
 
 def get_modules(input_modules: Sequence[str]) -> Set[str]:
     """
-    Takes in a sequence of module names and produce a set of paths to to their CircleCI configs.
+    Takes in a sequence of module names and/or paths to `config.yml` files
+    and produce a set of paths to to their CircleCI configs.
+    If a path to a config file is supplied - it must end in `config.yml`, otherwise
+    `.circleci/config.yml` will be added to the end of the path
     i.e.
-        input:  ['module1', 'module2', '.circleci/config.yml']
-        output: ['module1/.circleci/config.yml', 'module2/.circleci/config.yml', '.circleci/config.yml']
-    :param input_modules: sequence of module names
-    :return:
+        input:  ['module1', 'module2', '.circleci/config.yml', 'path/to/custom-config.yml']
+        output: [
+             'module1/.circleci/config.yml',
+             'module2/.circleci/config.yml',
+             '.circleci/config.yml',
+             'path/to/custom-config.yml',
+         ]
+    :param input_modules: sequence of module names and/or paths to config yaml files
+    :return: a set of paths to config yaml files
     """
     modules = set()
     for module in input_modules:

--- a/src/scripts/prepare_modules.py
+++ b/src/scripts/prepare_modules.py
@@ -74,7 +74,7 @@ def main() -> None:
     :return:
     """
     with open(getenv("MODULES_PATH", DEFAULT_MODULES_PATH)) as fd:
-        modules = get_modules(fd.read().splitlines() or [])  # pylint: disable=R1732
+        modules = get_modules(fd.readlines() or [])  # pylint: disable=R1732
 
     if not modules:
         print("Modules file is empty")

--- a/src/scripts/prepare_modules.py
+++ b/src/scripts/prepare_modules.py
@@ -24,14 +24,14 @@ def get_modules(input_modules: Sequence[str]) -> Set[str]:
             continue
 
         module = module.strip()
-        if module.endswith("config.yml"):
-            modules.add(f"{module}\n")
+        if module.endswith("config.yml") or module.endswith("config.yaml"):
+            modules.add(f"{module}")
             continue
 
         if module.endswith("/"):
-            module = f"{module}.circleci/config.yml\n"
+            module = f"{module}.circleci/config.yml"
         else:
-            module = f"{module}/.circleci/config.yml\n"
+            module = f"{module}/.circleci/config.yml"
 
         modules.add(module)
 
@@ -56,7 +56,7 @@ def dump_modules(modules: Iterable[str]) -> None:
     :return:
     """
     with open(getenv("MODULES_PATH", DEFAULT_MODULES_PATH), 'w') as fd:
-        fd.writelines(modules)
+        fd.writelines([x if x.endswith("\n") else f"{x}\n" for x in modules])
 
 
 def main() -> None:
@@ -65,7 +65,9 @@ def main() -> None:
     check that all exist and write unique paths into an output file
     :return:
     """
-    modules = get_modules(open(getenv("MODULES_PATH", DEFAULT_MODULES_PATH)).readlines() or [])  # pylint: disable=R1732
+    with open(getenv("MODULES_PATH", DEFAULT_MODULES_PATH)) as fd:
+        modules = get_modules(fd.read().splitlines() or [])  # pylint: disable=R1732
+
     if not modules:
         print("Modules file is empty")
 

--- a/src/tests/conftest.py
+++ b/src/tests/conftest.py
@@ -14,7 +14,8 @@ def modules_file(tmpdir, request):
     if hasattr(request, "param") and getattr(request, "param") is not None:
         path = Path(tmpdir / "modules.txt")
         with open(path, "w") as fd:
-            fd.writelines(request.param)
+            modules = [x if x.endswith("\n") else f"{x}\n" for x in request.param]
+            fd.writelines(modules)
 
         return path
     return None

--- a/src/tests/data/yaml/config.yaml
+++ b/src/tests/data/yaml/config.yaml
@@ -1,0 +1,5 @@
+commands:
+  command-one:
+    param: foo
+  command-two:
+    param: foo

--- a/src/tests/data/yaml/custom-config.yaml
+++ b/src/tests/data/yaml/custom-config.yaml
@@ -1,0 +1,5 @@
+commands:
+  command-one:
+    param: foo
+  command-two:
+    param: foo

--- a/src/tests/test_prepare_modules.py
+++ b/src/tests/test_prepare_modules.py
@@ -45,12 +45,7 @@ def test_dump_modules(monkeypatch, tmpdir):
 @pytest.mark.parametrize(
     "modules_file, expected",
     [
-        ([], ["module1/.circleci/config.yml\n", "module2/.circleci/config.yml\n"]),
         (["module1", "module2"], ["module1/.circleci/config.yml\n", "module2/.circleci/config.yml\n"]),
-        (
-            ["module1", "module3"],
-            ["module1/.circleci/config.yml\n", "module2/.circleci/config.yml\n", "module3/.circleci/config.yml\n"]
-        ),
         ([], []),
     ], indirect=["modules_file"]
 )
@@ -59,4 +54,18 @@ def test_main(monkeypatch, tmpdir, modules_file, expected):
     monkeypatch.setattr("src.scripts.prepare_modules.check_configs_exist", lambda x: True)
     main()
     with open(str(modules_file)) as fd:
-        assert fd.readlines().sort() == expected.sort()
+        assert sorted(fd.readlines()) == sorted(expected)
+
+
+def test_main_file_check(monkeypatch, tmpdir, test_data_dir):
+    modules_file = tmpdir / "modules.txt"
+    monkeypatch.setenv("MODULES_PATH", str(modules_file))
+    check_files = [
+        str(test_data_dir / 'yaml' / 'config.yaml') + "\n",
+        str(test_data_dir / 'yaml' / 'custom-config.yaml') + "\n",
+    ]
+
+    with open(modules_file, 'w') as fd:
+        fd.writelines(check_files)
+
+    main()

--- a/src/tests/test_prepare_modules.py
+++ b/src/tests/test_prepare_modules.py
@@ -7,11 +7,11 @@ from src.tests.conftest import does_not_raise
 @pytest.mark.parametrize(
     "modules, expected",
     [
-        (["module1", "module2"], {"module1/.circleci/config.yml\n", "module2/.circleci/config.yml\n"}),
-        (["module1/", "module2/"], {"module1/.circleci/config.yml\n", "module2/.circleci/config.yml\n"}),
-        (["module1/.circleci/config.yml\n"], {"module1/.circleci/config.yml\n"}),
-        (["module1/.circleci/config.yml"], {"module1/.circleci/config.yml\n"}),
-        ([".circleci/common_config.yml"], {".circleci/common_config.yml\n"}),
+        (["module1", "module2"], {"module1/.circleci/config.yml", "module2/.circleci/config.yml"}),
+        (["module1/", "module2/"], {"module1/.circleci/config.yml", "module2/.circleci/config.yml"}),
+        (["module1/.circleci/config.yml\n"], {"module1/.circleci/config.yml"}),
+        (["module1/.circleci/config.yml"], {"module1/.circleci/config.yml"}),
+        ([".circleci/common_config.yml"], {".circleci/common_config.yml"}),
         ([], set()),
         ([""], set()),
     ]


### PR DESCRIPTION
This PR changes how `src/scripts/prepare_modules.py:: get_modules` behaves. It was adding newlines to the paths that it produces so it would be easier to write these back to the file. This had proved to be more destructive than was thought at first. The `check_configs_exist` method was getting paths with newlines at the end and these were treated as a proper part of the path. This led to the `FileNotFound` error coming back from `.exist()` check.
I've decided to not add the newlines in `src/scripts/prepare_modules.py:: get_modules`, but instead add them right before the writing to the file happens in `src/scripts/prepare_modules.py:: dump_modules`