### PR TITLE
[semver:patch] Fix modules not splitting

### DIFF
--- a/src/common/description/mappings.txt
+++ b/src/common/description/mappings.txt
@@ -2,12 +2,9 @@ Mapping of regular expressions to modules and pipeline parameters.
 One mapping per line, semicolon-delimited.
 Structure of the mapping is as follows: `where_to_match:pattern; module_name; parameters`
 - `where_to_match` tells where the pattern will be applied. Can be `path`, `tag`, `branch`, `subject`
-- `pattern` a python regex that will be applied to `where_to_match`.
-    The pattern is case-sensitive and is matches from the beginning of the string (re.match is used)
-- `module_name` is the name of the module which CircleCI config will be joined into continuation config.
-    `module_name` must have `.circleci/config.yml` inside.
-- `parameters` a JSON blob with parameters to pass into continuation API. Parameters from mappings that
-    sit lower will override previous parameters
+- `pattern` a python regex that will be applied to `where_to_match`. The pattern is case-sensitive and is matches from the beginning of the string (re.match is used)
+- `module_name` is the name of the module which CircleCI config will be joined into continuation config. `module_name` must have `.circleci/config.yml` inside. If left blank - nothing will be added to the modules file for this mapping. Multiple comma-separated module names are allowed in this part of the mapping;
+- `parameters` a JSON blob with parameters to pass into continuation API. Parameters from mappings that sit lower will override previous parameters
 Lines that start with `#` are ignored.
 Some examples:
 (1) `path:module; module1; {"foo": "bar"}` this will add `{"foo": "bar"}` to the << params-path >> file

--- a/src/scripts/prepare_files.py
+++ b/src/scripts/prepare_files.py
@@ -115,12 +115,12 @@ def set_params_and_modules(diff: str, mappings: list[list[Any]]) -> None:
     param_path = getenv("PARAMS_PATH", '/tmp/pipeline-parameters.json')
     modules_path = getenv("MODULES_PATH", '/tmp/modules.txt')
     params = loads(getenv("DEFAULT_PARAMS", '{}'))
-    modules = [x.strip() if x.endswith("/") else f"{x.strip()}/" for x in getenv("DEFAULT_MODULES", "").split(",") if x]
+    modules = [x.strip() for x in getenv("DEFAULT_MODULES", "").split(",") if x]
     mappings = [x for x in mappings if check_mapping(x, diff)]
     for mapping in map(convert_mapping, mappings):
         module, new_params = mapping
         params |= new_params
-        modules.append(module.strip())
+        modules.extend(module.strip().split(','))
 
     with open(param_path, 'w') as fd:
         dump(params, fd)

--- a/src/scripts/prepare_files.py
+++ b/src/scripts/prepare_files.py
@@ -113,7 +113,7 @@ def set_params_and_modules(diff: str, mappings: list[list[Any]]) -> None:
     param_path = getenv("PARAMS_PATH", '/tmp/pipeline-parameters.json')
     modules_path = getenv("MODULES_PATH", '/tmp/modules.txt')
     params = loads(getenv("DEFAULT_PARAMS", '{}'))
-    modules = [x.strip() for x in getenv("DEFAULT_MODULES", "").split(",") if x]
+    modules = [x.strip() for x in getenv("DEFAULT_MODULES", "").split(",") if x.strip()]
     mappings = [x for x in mappings if check_mapping(x, diff)]
     for mapping in map(convert_mapping, mappings):
         module, new_params = mapping

--- a/src/scripts/prepare_files.py
+++ b/src/scripts/prepare_files.py
@@ -106,8 +106,6 @@ def match(pattern: re.Pattern, haystack: str, success_msg: str) -> bool:
 
 
 def convert_mapping(mapping: list[str]) -> Tuple[str, dict[str, Any]]:
-    if not mapping[1].endswith("/"):
-        mapping[1] = mapping[1] + "/"
     return mapping[1], loads(mapping[2])
 
 
@@ -126,7 +124,7 @@ def set_params_and_modules(diff: str, mappings: list[list[Any]]) -> None:
         dump(params, fd)
 
     with open(modules_path, 'w') as fd:
-        fd.writelines([x if x.endswith("\n") else f"{x}\n" for x in modules])
+        fd.writelines([x if x.endswith("\n") else f"{x}\n" for x in modules if x])
 
     log_block("set params", dumps(params, indent=4))
 

--- a/src/scripts/prepare_files.py
+++ b/src/scripts/prepare_files.py
@@ -124,7 +124,7 @@ def set_params_and_modules(diff: str, mappings: list[list[Any]]) -> None:
         dump(params, fd)
 
     with open(modules_path, 'w') as fd:
-        fd.writelines([x if x.endswith("\n") else f"{x}\n" for x in modules if x])
+        fd.writelines([x if x.endswith("\n") else f"{x}\n" for x in modules if x.strip()])
 
     log_block("set params", dumps(params, indent=4))
 

--- a/src/tests/test_prepare_files.py
+++ b/src/tests/test_prepare_files.py
@@ -177,6 +177,16 @@ def test_check_mapping(monkeypatch, mapping, changed_files, branch, tag, subject
             {"parameter": "value"}, "empty.txt"
         ),
         (
+            '{}', '', "module/file1",
+            [["path:.", " ", '{"parameter":"value"}']],
+            {"parameter": "value"}, "empty.txt"
+        ),
+        (
+            '{}', '', "module/file1",
+            [["path:.", ", ,", '{"parameter":"value"}']],
+            {"parameter": "value"}, "empty.txt"
+        ),
+        (
             "{}", "", "module/file1",
             [["path:^module", "module/", '{"parameter":"value"}'], ["path:^module", "module/", '{"parameter2":true}']],
             {"parameter": "value", "parameter2": True}, "set_modules_two_modules_same_name.txt"

--- a/src/tests/test_prepare_files.py
+++ b/src/tests/test_prepare_files.py
@@ -166,17 +166,22 @@ def test_check_mapping(monkeypatch, mapping, changed_files, branch, tag, subject
             {"parameter": "value"}, "set_modules_single_module.txt"
         ),
         (
+            '{}', '', "module/file1",
+            [["path:.", "module/,module_foo/,module_bar/", '{"parameter":"value"}']],
+            {"parameter": "value"}, "set_modules_multiple_modules_different_names.txt"
+        ),
+        (
             "{}", "", "module/file1",
             [["path:^module", "module", '{"parameter":"value"}'], ["path:^module", "module", '{"parameter2":true}']],
             {"parameter": "value", "parameter2": True}, "set_modules_two_modules_same_name.txt"
         ),
         (
-            '{"parameter2":true}', "module_foo, module_bar", "module/file1",
+            '{"parameter2":true}', "module_foo/, module_bar/", "module/file1",
             [["path:^module", "module", '{"parameter":"value"}']],
             {"parameter": "value", "parameter2": True}, "set_modules_multiple_modules_different_names.txt"
         ),
         (
-            '{"parameter2":true}', 'module_foo', "module/file1",
+            '{"parameter2":true}', 'module_foo/', "module/file1",
             [["path:^module_foo", "module", '{"parameter":"value"}']],
             {"parameter2": True}, "set_modules_single_module_foo.txt"
         ),

--- a/src/tests/test_prepare_files.py
+++ b/src/tests/test_prepare_files.py
@@ -106,9 +106,10 @@ def test_get_base_with_pull_raises(monkeypatch, capsys):
 @pytest.mark.parametrize(
     "mapping, expected, expectation",
     [
-        (["path:pattern", "module", '{"parameter":"value"}'], ("module/", {"parameter": "value"}), does_not_raise()),
+        (["path:pattern", "module", '{"parameter":"value"}'], ("module", {"parameter": "value"}), does_not_raise()),
         (["path:pattern", "module/", '{}'], ("module/", {}), does_not_raise()),
-        (["path:pattern", ".", '{}'], ("./", {}), does_not_raise()),
+        (["path:pattern", ".", '{}'], (".", {}), does_not_raise()),
+        (["path:pattern", "", '{}'], ("", {}), does_not_raise()),
         (["path:pattern", "module/", ''], ("module/", {}), pytest.raises(JSONDecodeError)),
         (["path:pattern", "module/", 'invalid obj'], ("module/", {}), pytest.raises(JSONDecodeError)),
     ]
@@ -162,7 +163,7 @@ def test_check_mapping(monkeypatch, mapping, changed_files, branch, tag, subject
     [
         (
             "{}", "", "module/file1",
-            [["path:^module", "module", '{"parameter":"value"}']],
+            [["path:^module/", "module/", '{"parameter":"value"}']],
             {"parameter": "value"}, "set_modules_single_module.txt"
         ),
         (
@@ -171,18 +172,23 @@ def test_check_mapping(monkeypatch, mapping, changed_files, branch, tag, subject
             {"parameter": "value"}, "set_modules_multiple_modules_different_names.txt"
         ),
         (
+            '{}', '', "module/file1",
+            [["path:.", "", '{"parameter":"value"}']],
+            {"parameter": "value"}, "empty.txt"
+        ),
+        (
             "{}", "", "module/file1",
-            [["path:^module", "module", '{"parameter":"value"}'], ["path:^module", "module", '{"parameter2":true}']],
+            [["path:^module", "module/", '{"parameter":"value"}'], ["path:^module", "module/", '{"parameter2":true}']],
             {"parameter": "value", "parameter2": True}, "set_modules_two_modules_same_name.txt"
         ),
         (
             '{"parameter2":true}', "module_foo/, module_bar/", "module/file1",
-            [["path:^module", "module", '{"parameter":"value"}']],
+            [["path:^module", "module/", '{"parameter":"value"}']],
             {"parameter": "value", "parameter2": True}, "set_modules_multiple_modules_different_names.txt"
         ),
         (
             '{"parameter2":true}', 'module_foo/', "module/file1",
-            [["path:^module_foo", "module", '{"parameter":"value"}']],
+            [["path:^module_foo", "module/", '{"parameter":"value"}']],
             {"parameter2": True}, "set_modules_single_module_foo.txt"
         ),
         (


### PR DESCRIPTION
This PR fixes the case when multiple modules were specified in a single mapping they would be added to the modules file as in a single string.
This case is allowed:
Mapping:
```text
path:.; module1,module2; {"run": true}
```
Expected modules file:
```
module1
module2
```
But it was missed during implementation, so modules were written to the file like so:
```
module1,module2
```