### PR TITLE
[semver:minor] Change how diff is fetched and add ability to run additional steps in `setup-and-continue` 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,13 +6,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.1.5] - 2022-01-016
+## [0.2.0] - 2022-01-016
+### Added
+- new `pre-continue` parameter in `setup-and-continue` job that allows to specify an array of steps to run
+  before continuation is triggered
+
+### Changed
+- in main, when trying to get the diff block, first try to run `find_diff_files` without specifying remote.
+  Specify remote only if it fails. I've found out that this approach reduces the number of git errors.
+
+## [0.1.5] - 2022-01-16
 ### Changed
 - specify remote when getting the diff. Now remote is assigned to a variable in main and passed to both get_base and
   find_diff_files
 - improves error message in the catch block when getting the diff
 
-## [0.1.4] - 2022-01-016
+## [0.1.4] - 2022-01-16
 ### Added
 - message that is printed out when the pattern matches in the commit subject.
 - exception handling in the case when getting the diff fails. This happens in cases when polyrepo is merged together
@@ -45,8 +54,9 @@ A minor release to indicate the fast pace of changes
 ### Added
 - Initial release of CircleCI orb.
 
-[Unreleased]: https://github.com/a-genius/monorepo-orb/compare/v0.1.4...main
-[0.1.5]: https://github.com/a-genius/monorepo-orb/compare/v0.1.5
+[Unreleased]: https://github.com/a-genius/monorepo-orb/compare/v0.2.0...main
+[0.2.0]: https://github.com/a-genius/monorepo-orb/releases/tag/v0.2.0
+[0.1.5]: https://github.com/a-genius/monorepo-orb/releases/tag/v0.1.5
 [0.1.4]: https://github.com/a-genius/monorepo-orb/releases/tag/v0.1.4
 [0.1.3]: https://github.com/a-genius/monorepo-orb/releases/tag/v0.1.3
 [0.1.2]: https://github.com/a-genius/monorepo-orb/releases/tag/v0.1.2

--- a/src/jobs/setup-and-continue.yml
+++ b/src/jobs/setup-and-continue.yml
@@ -46,6 +46,10 @@ parameters:
     description: ""
     type: executor
     default: python
+  pre-continue:
+    description: "Steps to run before triggering the continuation workflow"
+    type: steps
+    default: []
 
 
 executor: << parameters.executor >>
@@ -71,6 +75,7 @@ steps:
   - run:
       name: Validate continuation config
       command: circleci --skip-update-check config validate << parameters.continue-config >>
+  - steps: << parameters.pre-continue >>
   - continuation/continue:
       configuration_path: << parameters.continue-config >>
       parameters: << parameters.params-path >>

--- a/src/scripts/prepare_files.py
+++ b/src/scripts/prepare_files.py
@@ -206,14 +206,22 @@ def main() -> None:
     head = getenv('CIRCLE_SHA1', 'HEAD')
     subprocess.run(["git", "fetch", "--all"], check=True, stdout=sys.stdout, stderr=sys.stderr)
     try:
-        diff = find_diff_files(base, head, remote)
+        diff = find_diff_files(base, head)
     except subprocess.CalledProcessError as e:
         err = str(e)
         if hasattr(e, 'stderr'):  # pragma: no cover
             err = err + "\n" + str(e.stderr)
         log_block("Failed to get diff", err)
-        print(f"Using fallback base - {DEFAULT_BASE}")
-        diff = find_diff_files(DEFAULT_BASE, head)
+
+        try:
+            diff = find_diff_files(base, head, remote)
+        except subprocess.CalledProcessError as e:
+            err = str(e)
+            if hasattr(e, 'stderr'):  # pragma: no cover
+                err = err + "\n" + str(e.stderr)
+            log_block("Failed to get diff", err)
+            print(f"Using fallback base - {DEFAULT_BASE}")
+            diff = find_diff_files(DEFAULT_BASE, head)
 
     log_block("files changed", diff)
     set_params_and_modules(diff, mappings)


### PR DESCRIPTION
Small update that consists of 2 parts:
1. New `pre-continue` added to `setup-and-continue` job. This allows a user to specify an array of steps that will run before continuation triggers. A very similar thing can be achieved if one uses `pre-steps` or `post-steps` with `setup-without-continue` job and `circleci/continuation`, but this will require an additional pod, which may add an overhead to execution time.
2. In the main function, change how the diff block is fetched. First try to get diff without specifying origin, if this fails - try with origin (could help in cases where history is complicated). If both failed - get the diff using last commit