### PR TITLE
[semver: skip] changes executor to use next-gen runner image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,7 @@ orbs:
 executors:
   python:
     docker:
-      - image: circleci/python:3.7
+      - image: cimg/python:3.10
 
 # Pipeline Parameters
 ## These parameters are used internally by orb-tools. Skip to the Jobs section.


### PR DESCRIPTION
Changing the image that is used as a runner for CI to use a next-gen image, instead of a legacy one